### PR TITLE
Added Readme file and fixed provision script

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,19 @@
+# Algunos comandos de vagrant
+```
+vagrant up
+vagrant provision
+vagrant ssh
+```
+
+Recordar que el código estára en `/vagrant`
+
+# Algunos comandos de git
+```
+git status
+git add <archivo>
+git commit -m "<mensaje descriptivo del commit>"
+git push origin <nombre de la rama>
+git checkout <nombre de otra rama>
+git checkot -b <nombre de una nueva rama>
+git pull origin <nombre de una rama>
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,5 +5,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.box = "ubuntu/xenial64"
   config.vm.network "forwarded_port", guest: 5000, host: 5000
+  config.vm.provision "shell", path: "script.sh"
 
 end

--- a/script.sh
+++ b/script.sh
@@ -4,5 +4,5 @@ sudo add-apt-repository ppa:jonathonf/python-3.6 -y
 sudo apt-get update
 sudo apt-get install python3.6 -y
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
-curl -O https://bootstrap.pypa.io/get-pip.py /tmp/get-pip.py
+curl -s -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
 sudo python /tmp/get-pip.py

--- a/script.sh
+++ b/script.sh
@@ -1,6 +1,8 @@
-sudo apt update
+#!/bin/bash
+
 sudo add-apt-repository ppa:jonathonf/python-3.6 -y
 sudo apt-get update
 sudo apt-get install python3.6 -y
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
-sudo python get-pip.py
+curl -O https://bootstrap.pypa.io/get-pip.py /tmp/get-pip.py
+sudo python /tmp/get-pip.py


### PR DESCRIPTION
This PR add some commands commonly used with vagrant and git. Also, it improves the provision script so the `vagrant up` from scratch or `vagrant provision` works as expected, so by the end of the process Python 3.6+ and pip 9.0+ will be ready to be used.